### PR TITLE
fix(molgenis): Set elasticsearch starting memory to correct value.

### DIFF
--- a/charts/molgenis/Chart.yaml
+++ b/charts/molgenis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: MOLGENIS - helm stack (in BETA)
 name: molgenis
-version: 0.6.0
+version: 0.6.1
 sources:
 - https://github.com/molgenis/molgenis-ops-docker-helm.git
 icon: https://raw.githubusercontent.com/molgenis/molgenis-ops-docker-helm/master/charts/molgenis/catalogIcon-molgenis.svg

--- a/charts/molgenis/values.yaml
+++ b/charts/molgenis/values.yaml
@@ -89,7 +89,7 @@ molgenis:
 elasticsearch:
   type:
     small:
-      javaOpts: "-Xms1g -Xmx512m"
+      javaOpts: "-Xms512m -Xmx512m"
       resources:
         limits:
           cpu: 2


### PR DESCRIPTION
Starting memory was higher than max memory, causing small instances to refuse to start.