### PR TITLE
chore(jenkins): Bump the timeout of the preview job

### DIFF
--- a/charts/molgenis-jenkins/resources/preview/Jenkinsfile
+++ b/charts/molgenis-jenkins/resources/preview/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
                     sh "helm init --client-only"
                     sh "helm repo add molgenis ${HELM_REPO}"
                     sh "helm repo update"
-                    sh "helm install molgenis/molgenis --wait --timeout 180 -n preview-${TAG.toLowerCase()} --namespace preview-${TAG.toLowerCase()} --set molgenis.image.tag=${TAG} --set molgenis.image.repository=${LOCAL_REGISTRY} --set molgenis.environment=dev --set molgenis.type.kind=small --set persistence.enabled=false --set molgenis.adminPassword=admin"
+                    sh "helm install molgenis/molgenis --wait --timeout 240 -n preview-${TAG.toLowerCase()} --namespace preview-${TAG.toLowerCase()} --set molgenis.image.tag=${TAG} --set molgenis.image.repository=${LOCAL_REGISTRY} --set molgenis.environment=dev --set molgenis.type.kind=small --set persistence.enabled=false --set molgenis.adminPassword=admin"
                 }
                 hubotSend message: "Deployed https://preview-${TAG}.dev.molgenis.org"
             }


### PR DESCRIPTION
The new molgenis chart is a bit slower to boot.
Bump the timeout from 3 to 4 minutes.